### PR TITLE
Implement mock edit flow

### DIFF
--- a/frontend/src/api/routes/cv/mock.ts
+++ b/frontend/src/api/routes/cv/mock.ts
@@ -1,0 +1,18 @@
+export type { FormProps } from "@/pages/builder/data-form.tsx";
+
+export const mockCVApi = {
+    saveData: async (data: FormProps): Promise<{ editKey: string }> => {
+        const editKey = Math.random().toString(36).substring(2, 10);
+        localStorage.setItem(`cv_data_${editKey}`, JSON.stringify(data));
+        return new Promise((resolve) => setTimeout(() => resolve({ editKey }), 300));
+    },
+
+    getCVData: async (editKey: string): Promise<FormProps | null> => {
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                const stored = localStorage.getItem(`cv_data_${editKey}`);
+                resolve(stored ? JSON.parse(stored) as FormProps : null);
+            }, 300);
+        });
+    },
+};

--- a/frontend/src/pages/builder/cv-builder.tsx
+++ b/frontend/src/pages/builder/cv-builder.tsx
@@ -6,7 +6,8 @@ import { ChevronLeft, ChevronRight, Settings } from "lucide-react"
 
 
 
-import {useSearchParams} from "react-router";
+import { useNavigate } from "react-router";
+import { mockCVApi } from "@/api/routes/cv/mock.ts";
 import ModernTemplate from "@/components/pages/editor/modern-template.tsx";
 import ClassicTemplate from "@/components/pages/editor/classic-template.tsx";
 import CreativeTemplate from "@/components/pages/editor/creative-template.tsx";
@@ -31,7 +32,7 @@ const templates = {
 }
 
 export default function CVEditor() {
-    const [searchParams, ] = useSearchParams()
+    const navigate = useNavigate()
     const [formData, setFormData] = useState<FormProps | null>(null)
     const [selectedTemplate, setSelectedTemplate] = useState<string>("")
     const [showTemplateDialog, setShowTemplateDialog] = useState(true)
@@ -40,16 +41,21 @@ export default function CVEditor() {
     const [currentPage, setCurrentPage] = useState(1)
 
     useEffect(() => {
-        const dataParam = searchParams.get("data")
-        if (dataParam) {
-            try {
-                const parsedData = JSON.parse(decodeURIComponent(dataParam))
-                setFormData(parsedData)
-            } catch (error) {
-                console.error("Error parsing form data:", error)
+        async function fetchData() {
+            const key = localStorage.getItem("cv_edit_key")
+            if (!key) {
+                navigate("/cv")
+                return
+            }
+            const data = await mockCVApi.getCVData(key)
+            if (data) {
+                setFormData(data)
+            } else {
+                navigate("/cv")
             }
         }
-    }, [searchParams])
+        fetchData()
+    }, [navigate])
 
     const handleTemplateSelect = (template: string) => {
         setSelectedTemplate(template)

--- a/frontend/src/pages/builder/data-form.tsx
+++ b/frontend/src/pages/builder/data-form.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { useNavigate } from "react-router"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Progress } from "@/components/ui/progress"
@@ -15,6 +16,7 @@ import Step7Projects from "@/components/pages/builder/step7-projects.tsx";
 import Step8Summary from "@/components/pages/builder/step8-summary.tsx";
 import Step9Layout from "@/components/pages/builder/step9-layout.tsx";
 import Step10Export from "@/components/pages/builder/step10-export.tsx";
+import { mockCVApi } from "@/api/routes/cv/mock.ts";
 
 
 export type workExperienceProps = {
@@ -181,14 +183,17 @@ export default function ResumeBuilder() {
         return Object.keys(newErrors).length === 0
     }
 
-    const handleNext = () => {
+    const navigate = useNavigate()
+
+    const handleNext = async () => {
         if (validateStep(currentStep)) {
             if (!completedSteps.includes(currentStep)) {
                 setCompletedSteps((prev) => [...prev, currentStep])
             }
             if (currentStep === 8) {
-                // Redirect to CV editor after Professional Summary
-                window.location.href = `/cv-editor?data=${encodeURIComponent(JSON.stringify(formData))}`
+                const { editKey } = await mockCVApi.saveData(formData)
+                localStorage.setItem("cv_edit_key", editKey)
+                navigate("/edit")
             } else if (currentStep < steps.length) {
                 setCurrentStep(currentStep + 1)
             }


### PR DESCRIPTION
## Summary
- add mock CV API for saving and retrieving data
- save edit key in localStorage and navigate to edit page
- fetch CV data using edit key on the edit page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_685880208ef08333b45c7eceb3989944